### PR TITLE
Multiple sequences EM for standard Kalman Filter

### DIFF
--- a/pykalman/tests/test_standard.py
+++ b/pykalman/tests/test_standard.py
@@ -139,6 +139,14 @@ class KalmanFilterTests(object):
         for i in range(len(loglikelihoods) - 1):
             assert_true(loglikelihoods[i] < loglikelihoods[i + 1])
 
+        # check that EM with multiple sequences is working
+        datas = np.split(self.data.observations, [30, 60])
+        for i in range(len(loglikelihoods)):
+            kf.em_multiple(Xs=datas, n_iter=1)
+            loglikelihoods[i] = kf.loglikelihood(self.data.observations[:60])
+        for i in range(len(loglikelihoods) - 1):
+            assert_true(loglikelihoods[i] < loglikelihoods[i + 1])
+
     def test_kalman_initialize_parameters(self):
         self.check_dims(5, 1, {'transition_matrices': np.eye(5)})
         self.check_dims(1, 3, {'observation_offsets': np.zeros(3)})


### PR DESCRIPTION
Hello,

I have implemented a multiple sequence EM based on "Ghahramani and Hinton, 1996, Parameter estimation for linear dynamical systems". It introduced new method 'em_multiple' and function '_em_multiple' and generalized existing update functions for M step to work on multiple sequences (well, technically I squeeze a list of numpy arrays into one array with vstack and keep indices of the beginning of each sequence). Everything else should still work, but an extra layer is added, as _em_multiple is more general than _em.

But, loglikelihood method has not been adapted to work with multiple sequences, thats why I consider the test I added as 'dirty'. And varying parameters should crash with multiple sequences, due to the way I implement the E step of EM.

Well, please let me know if it is clean enough or what change you would like to see to accept this contribution.

Best regards.