### PR TITLE
fix KalmanFilter documentation

### DIFF
--- a/pykalman/standard.py
+++ b/pykalman/standard.py
@@ -116,7 +116,7 @@ def _loglikelihoods(observation_matrices, observation_offsets,
 
     Parameters
     ----------
-    observation_matrices : [n_timesteps, n_dim_obs, n_dim_obs] or [n_dim_obs,
+    observation_matrices : [n_timesteps, n_dim_obs, n_dim_state] or [n_dim_obs,
     n_dim_state] array
         observation matrices for t in [0...n_timesteps-1]
     observation_offsets : [n_timesteps, n_dim_obs] or [n_dim_obs] array
@@ -308,8 +308,8 @@ def _filter(transition_matrices, observation_matrices, transition_covariance,
     transition_matrices : [n_timesteps-1,n_dim_state,n_dim_state] or
     [n_dim_state,n_dim_state] array-like
         state transition matrices
-    observation_matrices : [n_timesteps, n_dim_obs, n_dim_obs] or [n_dim_obs, \
-    n_dim_obs] array-like
+    observation_matrices : [n_timesteps, n_dim_obs, n_dim_state] or [n_dim_obs, \
+    n_dim_state] array-like
         observation matrix
     transition_covariance : [n_timesteps-1,n_dim_state,n_dim_state] or
     [n_dim_state,n_dim_state] array-like


### PR DESCRIPTION
There is a typo with the dimension of observation matrices. This was partly fixed in commit 5b75836b by @duckworthd but there were other docstrings affected.

Also, I think that the sphinx doc page http://pykalman.github.io/#kalmanfilter should be updated accordingly because even the previous fix is not visible (one of my student fell in this trap  ;-) ). 