### PR TITLE
fixed: can't compute Gaussian density on a masked observation array

### DIFF
--- a/pykalman/standard.py
+++ b/pykalman/standard.py
@@ -144,6 +144,7 @@ def _loglikelihoods(observation_matrices, observation_offsets,
     for t in range(n_timesteps):
         observation = observations[t]
         if not np.any(np.ma.getmask(observation)):
+            observation_data = np.ma.getdata(observation)
             observation_matrix = _last_dims(observation_matrices, t)
             observation_offset = _last_dims(observation_offsets, t, ndims=1)
             predicted_state_mean = _last_dims(
@@ -165,7 +166,7 @@ def _loglikelihoods(observation_matrices, observation_offsets,
                 + observation_covariance
             )
             loglikelihoods[t] = log_multivariate_normal_density(
-                observation[np.newaxis, :],
+                observation_data[np.newaxis, :],
                 predicted_observation_mean[np.newaxis, :],
                 predicted_observation_covariance[np.newaxis, :, :]
             )


### PR DESCRIPTION
This fixes a small issue: the KalmanFilter.loglikelihood() method automatically parses its input into a MaskedArray, but then tries to directly pass elements of this array to log_multivariate_normal_density(), which raises an error because solve_triangular() does not support masked arrays. 
The solution is to pass just the data from the masked array. This is valid because the likelihood is already only computed at timesteps where the observation is not masked. 