### PR TITLE
[MNT] temporarily remove missing init file check

### DIFF
--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -20,9 +20,6 @@ jobs:
         uses: tj-actions/changed-files@v45
       - name: run pre-commit hooks on modified files
         run: pre-commit run --color always --files ${{ steps.changed-files.outputs.all_changed_files }} --show-diff-on-failure
-      - name: check missing __init__ files
-        run: build_tools/fail_on_missing_init_files.sh
-        shell: bash
 
   build:
 


### PR DESCRIPTION
the missing init file check is not working - temporarily removing to ensure CI that completes.