### PR TITLE
Revert "[MNT] temporarily remove missing init file check"

### DIFF
--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -20,6 +20,9 @@ jobs:
         uses: tj-actions/changed-files@v45
       - name: run pre-commit hooks on modified files
         run: pre-commit run --color always --files ${{ steps.changed-files.outputs.all_changed_files }} --show-diff-on-failure
+      - name: check missing __init__ files
+        run: build_tools/fail_on_missing_init_files.sh
+        shell: bash
 
   build:
 

--- a/build_tools/fail_on_missing_init_files.sh
+++ b/build_tools/fail_on_missing_init_files.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Script to search for missing init FILES.
+# Script to search for missing init files.
 set -euxo pipefail
 
 FILES=$( find ./sktime -type d '!' -exec test -e "{}/__init__.py" ";" -not -path "**/__pycache__" -not -path "**/datasets/data*" -not -path "**/contrib/*" -print )


### PR DESCRIPTION
Reverts pykalman/pykalman#125

#125 removed the missing init file check since it did not work - this PR intends to revert it once the issue is diagnosed and fixed.