### PR TITLE
[MNT] fix `pykalman` logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Welcome to pykalman
 
-<a href="https://github.com/pykalman/pykalman"><img src="https://github.com/pykalman/pykalman/blob/main/docs/source/images/pykalman-logo.png" width="175" align="right" /></a>
+<a href="https://github.com/pykalman/pykalman"><img src="https://github.com/pykalman/pykalman/blob/main/doc/source/images/pykalman-logo.png" width="175" align="right" /></a>
 
 **the dead-simple Kalman Filter, Kalman Smoother, and EM library for Python.**
 


### PR DESCRIPTION
Fixes a typo in the link to the logo in the readme.