### PR TITLE
License update - acknowledge pykalman developers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,9 +4,10 @@ contained therein.
 
 New BSD License
 
+Copyright (c) 2025 - present, The pykalman developers.
 Copyright (c) 2012 Daniel Duckworth.
-All rights reserved.
 
+All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -20,7 +21,6 @@ modification, are permitted provided that the following conditions are met:
      its contributors may be used to endorse or promote products
      derived from this software without specific prior written
      permission.
-
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE


### PR DESCRIPTION
Adds an updated copyright with "pykalman developers".

Does not remove Daniel Duckworth or the original copyright, ensuring we still satisfy the previous license.