### PR TITLE
[MNT] developer dependency isolation test

### DIFF
--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -24,8 +24,27 @@ jobs:
         run: build_tools/fail_on_missing_init_files.sh
         shell: bash
 
+  test-nodevdeps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+
+      - name: Install pykalman and dependencies
+        run: |
+          python -m pip install .
+
+      - name: Run pytest-free tests
+        run: |
+          python pykalman/_nopytest_tests.py
+
   build:
-    needs: code-quality
+    needs: test-nodevdeps
     name: build
     strategy:
       matrix:

--- a/pykalman/_nopytest_tests.py
+++ b/pykalman/_nopytest_tests.py
@@ -1,0 +1,7 @@
+"""Tests to run without pytest, to check pytest isolation."""
+
+from skbase import all_objects
+
+# all_objects crawls all modules excepting pytest test files
+# if it encounters an unisolated import, it will throw an exception
+results = all_objects()

--- a/pykalman/_nopytest_tests.py
+++ b/pykalman/_nopytest_tests.py
@@ -1,6 +1,6 @@
 """Tests to run without pytest, to check pytest isolation."""
 
-from skbase import all_objects
+from skbase.lookup import all_objects
 
 # all_objects crawls all modules excepting pytest test files
 # if it encounters an unisolated import, it will throw an exception

--- a/pykalman/_nopytest_tests.py
+++ b/pykalman/_nopytest_tests.py
@@ -4,4 +4,4 @@ from skbase.lookup import all_objects
 
 # all_objects crawls all modules excepting pytest test files
 # if it encounters an unisolated import, it will throw an exception
-results = all_objects()
+results = all_objects(package_name="pykalman")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
 requires-python = ">=3.9,<3.14"
 dependencies = [
     "numpy<3",
+    "packaging",
     "scikit-base<0.13.0",
     "scipy<2.0.0",
 ]


### PR DESCRIPTION
Adds a CI element that tests isolation of the developer dependencies - which are otherwise always installed.

This detects missing dependencies in module level imports, such as the problem in https://github.com/pykalman/pykalman/pull/145.

The missing dependency was originally not detected as it was implied by the `tests` dependency set.