### PR TITLE
[MNT] add `packaging` as explicit dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
 requires-python = ">=3.9,<3.14"
 dependencies = [
     "numpy<3",
+    "packaging",
     "scikit-base<0.13.0",
     "scipy<2.0.0",
 ]


### PR DESCRIPTION
adds `packaging` as an explicit dependency - it is required for the case distinction in the `numpy` case, as we check the environment for the `numpy` version using `packaging` (used by `skbase`).