### PR TITLE
[MNT] readthedocs hosting for documentation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,26 @@
+
+
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version, and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
+# Build documentation in the "doc/source" directory with Sphinx
+sphinx:
+   configuration: doc/source/conf.py
+
+# Optionally, but recommended,
+# declare the Python requirements required to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#    install:
+#    - requirements: docs/requirements.txt
+        
+

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,3 @@
-
-
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
@@ -22,5 +20,3 @@ sphinx:
 # python:
 #    install:
 #    - requirements: docs/requirements.txt
-        
-

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,9 +14,10 @@ build:
 sphinx:
    configuration: doc/source/conf.py
 
-# Optionally, but recommended,
-# declare the Python requirements required to build your documentation
-# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#    install:
-#    - requirements: docs/requirements.txt
+# Dependencies for the documentation build
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs


### PR DESCRIPTION
Towards https://github.com/pykalman/pykalman/issues/150 - adds readthedocs hosting for the pykalman documentation.