### PR TITLE
[MNT] update deprecated `sphinx` extensions

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -27,11 +27,11 @@ sys.path.insert(0, os.path.abspath('../../'))
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.todo',
-    'sphinx.ext.pngmath',
-    'numpydoc'
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.todo",
+    "sphinx.ext.imgmath",
+    "numpydoc",
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Towards #150.

Replaces deprecated sphinx extension `pngmath` with `imgmath`.