### PR TITLE
[MNT] update documentation links to readthedocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 :rocket: **Version 0.10.1 out now!** [Check out the release notes here](https://github.com/pykalman/pykalman/blob/main/CHANGELOG.md).
 
-|  | **[Documentation](https://pykalman.github.io/)** · **[Tutorials](https://github.com/pykalman/pykalman/tree/main/examples)** |
+|  | **[Documentation](https://pykalman.readthedocs.io/en/latest/)** · **[Tutorials](https://github.com/pykalman/pykalman/tree/main/examples)** |
 |---|---|
 | **Open&#160;Source** | [![BSD 3-clause](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://github.com/pykalman/pykalman/blob/main/LICENSE) |
 | **Community** | [![!discord](https://img.shields.io/static/v1?logo=discord&label=discord&message=chat&color=lightgreen)](https://discord.com/invite/54ACzaFsn7) [![!LinkedI](https://img.shields.io/static/v1?logo=linkedin&label=LinkedIn&message=news&color=lightblue)](https://www.linkedin.com/company/scikit-time/) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ all = [
 [project.urls]
 Homepage = "https://github.com/pykalman/pykalman"
 Repository = "https://github.com/pykalman/pykalman"
-Documentation = "https://pykalman.github.io/"
+Documentation = "https://pykalman.readthedocs.io/en/latest/"
 Download = "https://pypi.org/project/pykalman/"
 
 [project.license]


### PR DESCRIPTION
The readthedocs build seems to be running - updates the documentation links to point to readthedocs.

Fixes #150.