### PR TITLE
[MNT] move release to trusted publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,26 +10,32 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    permissions:
+      id-token: write
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         make install
+
     - name: Run test
       run: |
         make test
+
     - name: Install build dependencies
       run: |
         make install-build-deps
-    - name: Release package
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-      run: |
-        make release
+
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: wheelhouse/


### PR DESCRIPTION
Moves the release to trusted publishers.

All secrets have been removed from the repo.