### PR TITLE
[DOC] README - credit to duckworthd

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <a href="https://github.com/pykalman/pykalman"><img src="https://github.com/pykalman/pykalman/blob/main/doc/source/images/pykalman-logo-with-name.png" width="175" align="right" /></a>
 
-**the dead-simple Kalman Filter, Kalman Smoother, and EM library for Python.**
+**The dead-simple Kalman Filter, Kalman Smoother, and EM library for Python.** Created by Daniel Duckworth (@duckworthd).
 
 `pykalman` is a Python library for Kalman filtering and smoothing, providing efficient algorithms for state estimation in time series. It includes tools for linear dynamical systems, parameter estimation, and sequential data modeling. The library supports the Kalman Filter, Unscented Kalman Filter, and EM algorithm for parameter learning.
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 <a href="https://github.com/pykalman/pykalman"><img src="https://github.com/pykalman/pykalman/blob/main/doc/source/images/pykalman-logo-with-name.png" width="175" align="right" /></a>
 
-**The dead-simple Kalman Filter, Kalman Smoother, and EM library for Python.** Created by Daniel Duckworth (@duckworthd).
+**The dead-simple Kalman Filter, Kalman Smoother, and EM library for Python.**
 
 `pykalman` is a Python library for Kalman filtering and smoothing, providing efficient algorithms for state estimation in time series. It includes tools for linear dynamical systems, parameter estimation, and sequential data modeling. The library supports the Kalman Filter, Unscented Kalman Filter, and EM algorithm for parameter learning.
+
+Originally created by Daniel Duckworth (@duckworthd).
 
 :rocket: **Version 0.10.2 out now!** [Check out the release notes here](https://github.com/pykalman/pykalman/blob/main/CHANGELOG.md).
 


### PR DESCRIPTION
The contributors pane of GitHub now acknowledges me as the first contributor to `pykalman`, likely due to the large number of (many smaller or maintenance focused) PR. Imo this unfairly diminishes the contribution of @duckworthd. Unfortunately, this is done by a black-box algorithm in GitHub, so we have no direct influence on the ranking afaik.

To offset this, I think we should add a sentence "originally created by @duckworthd" to the readme intro - this PR adds such a sentence, prominently placed.