### PR TITLE
Fix covariance weight usage in UKF cross-covariance

### DIFF
--- a/pykalman/unscented.py
+++ b/pykalman/unscented.py
@@ -382,7 +382,7 @@ def unscented_filter_correct(
     # Calculate Cov(x_t, z_t | z_{0:t-1})
     sigma_pair = (
         ((points_pred.points - moments_pred.mean).T)
-        .dot(np.diag(points_pred.weights_mean))
+        .dot(np.diag(points_pred.weights_covariance))
         .dot(obs_points_pred.points - obs_moments_pred.mean)
     )
 


### PR DESCRIPTION
## Bug Description

The AWS provider currently only checks `SecretString` when retrieving secrets from AWS Secrets Manager.
If a secret is stored as `SecretBinary`, the provider returns an error even though the secret exists.

---

## Current Implementation

```go
result, err := a.client.GetSecretValue(ctx, input)
if err != nil {
	return nil, err
}

if result.SecretString == nil {
	return nil, fmt.Errorf("secret %s has no string value", secretName)
}

return []byte(*result.SecretString), nil
```

---

## Steps to Reproduce

1. Store a secret in AWS Secrets Manager using `SecretBinary`.
2. The request fails because `SecretString` is not present.

---

## Expected Behavior

The provider should support both `SecretString` and `SecretBinary` returned by the AWS `GetSecretValue` API.

---

## Actual Behavior

```text
secret <name> has no string value
```

---

## Reproducibility

Always

---

## Reference

https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
