### PR TITLE
Fix incorrect observation dimension in UKF docstrings

### DIFF
--- a/pykalman/unscented.py
+++ b/pykalman/unscented.py
@@ -864,7 +864,7 @@ class UnscentedKalmanFilter(UnscentedMixin):
 
         Parameters
         ----------
-        Z : [n_timesteps, n_dim_state] array
+        Z : [n_timesteps, n_dim_obs] array
             Z[t] = observation at time t.  If Z is a masked array and any of
             Z[t]'s elements are masked, the observation is assumed missing and
             ignored.


### PR DESCRIPTION
The filter() docstrings in the Unscented Kalman Filter classes incorrectly documented the observation input Z as:
```bash
Z : [n_timesteps, n_dim_state]
```
However, observations belong to the observation space (n_dim_obs), not the state space (n_dim_state).
For example:
```bash
ukf = UnscentedKalmanFilter(n_dim_state=4, n_dim_obs=2)
```
Docstring implied:
```bash
Z : [T, 4]
```
Correct shape:
```bash
Z : [T, 2]
```